### PR TITLE
Modified colors.xml and themes.xml

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <color name="blue_sky">#5ba1d6</color>
     <color name="blue_dark">#34688F</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="link_color">#2a2a46</color>
 
     <color name="leaf_main">#765BD5</color>
     <color name="leaf_spill">#5944a3</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -20,7 +20,7 @@
         <item name="soundfont_warning_background">@color/blue_sky</item>
         <item name="soundfont_warning_frame">@color/blue_dark</item>
         <item name="soundfont_warning_text">@color/white</item>
-        <item name="soundfont_warning_link">@color/blue_dark</item>
+        <item name="soundfont_warning_link">@color/link_color</item>
         <item name="drop_down_bg">#FFFFFF</item>
     </style>
 


### PR DESCRIPTION
Hello,

I just discovered an issue with the color. The color of the link was originally too light, which resulted in insufficient color contrast and made it very difficult to read. Therefore, it should be changed to dark blue.

before：
![before](https://github.com/user-attachments/assets/63897855-58e4-4650-a4ee-7a17e6721467)

after：
![after](https://github.com/user-attachments/assets/914bfe9e-d82e-4987-aa9c-0692c9846ad9)
